### PR TITLE
Bump upper bounds for ghc-9.6.1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 _sdists/
+dist-newstyle/

--- a/composite-base.cabal
+++ b/composite-base.cabal
@@ -58,7 +58,7 @@ library
     , mtl >=2.2.1 && <2.3
     , profunctors >=5.2.1 && <5.7
     , template-haskell >=2.11.1.0 && <2.22
-    , text >=1.2.2.2 && <1.3
+    , text >=1.2.2.2 && <2.1
     , transformers >=0.5.2.0 && <0.6
     , transformers-base >=0.4.4 && <0.5
     , unliftio-core >=0.1.0.0 && <0.3.0.0
@@ -110,8 +110,8 @@ test-suite composite-base-test
     , monad-control >=1.0.2.2 && <1.1
     , mtl >=2.2.1 && <2.3
     , profunctors >=5.2.1 && <5.7
-    , template-haskell >=2.11.1.0 && <2.19
-    , text >=1.2.2.2 && <1.3
+    , template-haskell >=2.11.1.0 && <2.20
+    , text >=1.2.2.2 && <2.1
     , transformers >=0.5.2.0 && <0.6
     , transformers-base >=0.4.4 && <0.5
     , unliftio-core >=0.1.0.0 && <0.3.0.0

--- a/composite-base.cabal
+++ b/composite-base.cabal
@@ -55,11 +55,11 @@ library
     , exceptions >=0.8.3 && <0.11
     , lens >=4.15.4 && <5.3
     , monad-control >=1.0.2.2 && <1.1
-    , mtl >=2.2.1 && <2.3
+    , mtl >=2.2.1 && <2.4
     , profunctors >=5.2.1 && <5.7
     , template-haskell >=2.11.1.0 && <2.22
     , text >=1.2.2.2 && <2.1
-    , transformers >=0.5.2.0 && <0.6
+    , transformers >=0.5.2.0 && <0.7
     , transformers-base >=0.4.4 && <0.5
     , unliftio-core >=0.1.0.0 && <0.3.0.0
     , vinyl >=0.5.3 && <0.15
@@ -108,11 +108,11 @@ test-suite composite-base-test
     , hspec
     , lens >=4.15.4 && <5.3
     , monad-control >=1.0.2.2 && <1.1
-    , mtl >=2.2.1 && <2.3
+    , mtl >=2.2.1 && <2.4
     , profunctors >=5.2.1 && <5.7
-    , template-haskell >=2.11.1.0 && <2.20
+    , template-haskell >=2.11.1.0 && <2.21
     , text >=1.2.2.2 && <2.1
-    , transformers >=0.5.2.0 && <0.6
+    , transformers >=0.5.2.0 && <0.7
     , transformers-base >=0.4.4 && <0.5
     , unliftio-core >=0.1.0.0 && <0.3.0.0
     , vinyl >=0.5.3 && <0.15

--- a/test/RecordSpec.hs
+++ b/test/RecordSpec.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 902
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+#endif
+
 module RecordSpec where
 
 import Composite.Record


### PR DESCRIPTION
I suppressed a warning with `ghc >=9.2` in the test suite then loosened bounds to get compilation going first for `ghc-9.4.5` and then for `ghc-9.6.1`.

```
$ cabal test all --test-show-details=always
Resolving dependencies...
Build profile: -w ghc-9.6.1 -O1
In order, the following will be built (use -v for more details):
 - composite-base-0.8.2.1 (lib) (configuration changed)
 - composite-base-0.8.2.1 (test:composite-base-test) (configuration changed)
Configuring library for composite-base-0.8.2.1..
Preprocessing library for composite-base-0.8.2.1..
Building library for composite-base-0.8.2.1..
Configuring test suite 'composite-base-test' for composite-base-0.8.2.1..
Preprocessing test suite 'composite-base-test' for composite-base-0.8.2.1..
Building test suite 'composite-base-test' for composite-base-0.8.2.1..
Running 1 test suites...
Test suite composite-base-test: RUNNING...

Basic record utilities
  Supports construction and deconstruction of a Rec Identity [✔]
  Supports construction and deconstruction of a Rec f [✔]
  Supports construction and deconstruction of a Rec f (Contravariant) [✔]
  Supports lensing in a Rec Identity [✔]
  Supports lensing in a Rec Maybe [✔]
  Supports lensing in a Rec Predicate [✔]
withLensesAndProxies
  works for simple fields [✔]
  works for declaration blocks with non-fields in them [✔]
  works with parameterized fields [✔]
withOpticsAndProxies
  works for simple fields [✔]

Finished in 0.0032 seconds
10 examples, 0 failures

Test suite composite-base-test: PASS
```